### PR TITLE
Improve auto-detection of coordinate keys

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,9 +1,9 @@
-name: Python package
+name: push
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
     strategy:
@@ -22,4 +22,18 @@ jobs:
         pip install -e .[testing]
     - name: Test with pytest
       run: |
-        pytest -rxs
+        pytest -rxs --coverage
+    - name: Coveralls
+      uses: AndreMiras/coveralls-python-action@v20201129
+      with:
+        parallel: true
+        flag-name: Unit Test
+
+  coveralls_finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: AndreMiras/coveralls-python-action@v20201129
+      with:
+        parallel-finished: true

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -22,7 +22,7 @@ jobs:
         pip install -e .[testing]
     - name: Test with pytest
       run: |
-        pytest -rxs --coverage
+        pytest
     - name: Coveralls
       uses: AndreMiras/coveralls-python-action@v20201129
       with:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,0 +1,25 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[testing]
+    - name: Test with pytest
+      run: |
+        pytest -rxs

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,9 @@
 extcats
 *******
 
+.. image:: https://coveralls.io/repos/github/AmpelProject/extcats/badge.svg?branch=master
+:target: https://coveralls.io/github/AmpelProject/extcats?branch=master
+
 tools to organize and query astronomical catalogs
 #################################################
 

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ extcats
 *******
 
 .. image:: https://coveralls.io/repos/github/AmpelProject/extcats/badge.svg?branch=master
-:target: https://coveralls.io/github/AmpelProject/extcats?branch=master
+   :target: https://coveralls.io/github/AmpelProject/extcats?branch=master
 
 tools to organize and query astronomical catalogs
 #################################################

--- a/extcats/CatalogQuery.py
+++ b/extcats/CatalogQuery.py
@@ -163,6 +163,7 @@ class CatalogQuery():
         else:
             self.has_hp = False
             self.hp_index = False
+            self.hp_key = None
             self.logger.debug("no indexed HEALPix partition found for this catalog.")
 
 

--- a/extcats/CatalogQuery.py
+++ b/extcats/CatalogQuery.py
@@ -28,7 +28,7 @@ class CatalogQuery():
         class to query external catalogs.
     """
     
-    def __init__(self, cat_name, ra_key, dec_key, coll_name = "srcs", 
+    def __init__(self, cat_name, ra_key=None, dec_key=None, coll_name = "srcs", 
         dbclient = None, logger =  None):
         """
             Connect to the desired database and collection. Retrive information
@@ -85,10 +85,9 @@ class CatalogQuery():
         # check for healpix and sphere2d support
         self.check_healpix()
         self.check_sphere2d()
+        self.guess_coord_keys()
         
         # check if query relevant keys are contained in the database
-        self.ra_key = ra_key
-        self.dec_key = dec_key
         important_keys  = [self.ra_key, self.dec_key]
         if self.has_hp:
             important_keys.append(self.hp_key)
@@ -112,6 +111,16 @@ class CatalogQuery():
         
         # now set default query method
         self.autoset_method()
+
+
+    def guess_coord_keys(self, ra_key=None, dec_key=None):
+        doc = self.cat_db["meta"].find_one({"_id": "keys"})
+        if doc:
+            self.ra_key = ra_key or doc["ra"]
+            self.dec_key = dec_key or doc["dec"]
+        else:
+            self.ra_key = ra_key
+            self.dec_key = dec_key
 
 
     def check_healpix(self):

--- a/extcats/CatalogQuery.py
+++ b/extcats/CatalogQuery.py
@@ -255,7 +255,8 @@ class CatalogQuery():
             hp_nest = self.hp_nest, hp_resol = self.hp_resol, 
             circular = circular, ra_key = self.ra_key, dec_key = self.dec_key,
             find_one = find_one, pre_filter = qfunc_args.get('pre_filter'), 
-            post_filter = qfunc_args.get('post_filter'), logger = self.logger)
+            post_filter = qfunc_args.get('post_filter'), logger = self.logger,
+            projection = qfunc_args.get('projection', {'_id': 0, 'pos': 0}))
 
 
     def findwithin_9HEALPix(self, ra, dec, find_one = False, **qfunc_args):
@@ -290,7 +291,8 @@ class CatalogQuery():
         return searcharound_9HEALPix(
             ra = ra, dec = dec, src_coll = self.src_coll, hp_key = self.hp_key, 
             hp_order = self.hp_order, hp_nest = self.hp_nest, hp_resol = self.hp_resol, find_one = find_one, 
-            pre_filter = qfunc_args.get('pre_filter'), post_filter = qfunc_args.get('post_filter'))
+            pre_filter = qfunc_args.get('pre_filter'), post_filter = qfunc_args.get('post_filter'),
+            projection = qfunc_args.get('projection', {'_id': 0, 'pos': 0}))
 
 
     def findwithin_2Dsphere(self, ra, dec, rs_arcsec, find_one = False, **qfunc_args):
@@ -334,7 +336,8 @@ class CatalogQuery():
             ra = ra, dec = dec, rs_arcsec = rs_arcsec, 
             src_coll = self.src_coll, s2d_key = self.s2d_key, find_one = find_one, 
             logger = self.logger, pre_filter = qfunc_args.get('pre_filter'), 
-            post_filter = qfunc_args.get('post_filter'))
+            post_filter = qfunc_args.get('post_filter'),
+            projection = qfunc_args.get('projection', {'_id': 0, 'pos': 0}))
 
 
     def findwithin_RAW(self, ra, dec, rs_arcsec, box_scale = 2., find_one = False, **qfunc_args):
@@ -375,7 +378,8 @@ class CatalogQuery():
         return searcharound_RAW(
             ra = ra, dec = dec, rs_arcsec = rs_arcsec, src_coll = self.src_coll,
             ra_key = self.ra_key, dec_key = self.dec_key, box_scale = box_scale, find_one = find_one,
-            pre_filter = qfunc_args.get('pre_filter'), post_filter = qfunc_args.get('post_filter'))
+            pre_filter = qfunc_args.get('pre_filter'), post_filter = qfunc_args.get('post_filter'),
+            projection = qfunc_args.get('projection', {'_id': 0, 'pos': 0}))
 
 
     def findwithin(self, ra, dec, rs_arcsec, method = None, **qfunc_args):

--- a/extcats/CatalogQuery.py
+++ b/extcats/CatalogQuery.py
@@ -69,17 +69,17 @@ class CatalogQuery():
         self.logger.debug("using mongo client at %s:%d"%(self.dbclient.address))
         
         # find database and collection
-        if not cat_name in self.dbclient.database_names():
+        if not cat_name in self.dbclient.list_database_names():
             raise KeyError("cannot find database %s in client."%(cat_name))
         self.cat_db = self.dbclient[cat_name]
-        if not coll_name in self.cat_db.collection_names():
+        if not coll_name in self.cat_db.list_collection_names():
             raise KeyError("cannot find collection %s in database %s"%(coll_name, self.cat_db.name))
         self.src_coll = self.cat_db[coll_name]
         self.logger.info("connected to collection %s of database %s. %s documents in source collection %s."%
-            (coll_name, self.cat_db.name, self.src_coll.count(), coll_name))
+            (coll_name, self.cat_db.name, self.src_coll.count_documents({}), coll_name))
         
         # read metadata for the catalog
-        if not "meta" in self.cat_db.collection_names():
+        if not "meta" in self.cat_db.list_collection_names():
             raise KeyError("cannot find metadata collection in database %s"%self.cat_db.name)
         
         # check for healpix and sphere2d support

--- a/extcats/CatalogQuery.py
+++ b/extcats/CatalogQuery.py
@@ -121,6 +121,10 @@ class CatalogQuery():
         else:
             self.ra_key = ra_key
             self.dec_key = dec_key
+        if self.ra_key is None:
+            raise ValueError("ra_key not found in metadata or provided as kwarg")
+        if self.dec_key is None:
+            raise ValueError("dec_key not found in metadata or provided as kwarg")
 
 
     def check_healpix(self):

--- a/extcats/catquery_utils.py
+++ b/extcats/catquery_utils.py
@@ -210,7 +210,7 @@ def searcharound_HEALPix(
         return Table(qresults)
     else:
         tab = Table(qresults)
-        if ra_key not in tab or dec_key not in tab and sphere2_key is not None:
+        if ra_key not in tab or dec_key not in tab and sphere2d_key is not None:
             ra_key, dec_key = "_ra", "_dec"
             tab[ra_key], tab[dec_key] = zip(*(q[sphere2d_key]["coordinates"] for q in qresults))
         dists = get_distances(ra = ra, dec = dec, table = tab, ra_key = ra_key, dec_key = dec_key)

--- a/extcats/catquery_utils.py
+++ b/extcats/catquery_utils.py
@@ -210,7 +210,8 @@ def searcharound_HEALPix(
         return Table(qresults)
     else:
         tab = Table(qresults)
-        if ra_key not in tab or dec_key not in tab and sphere2d_key is not None:
+        cols = set(tab.keys())
+        if (ra_key not in cols or dec_key not in cols) and sphere2d_key is not None:
             ra_key, dec_key = "_ra", "_dec"
             tab[ra_key], tab[dec_key] = zip(*(q[sphere2d_key]["coordinates"] for q in qresults))
         dists = get_distances(ra = ra, dec = dec, table = tab, ra_key = ra_key, dec_key = dec_key)

--- a/extcats/catquery_utils.py
+++ b/extcats/catquery_utils.py
@@ -57,7 +57,7 @@ def filters_logical_and(f1, f2, f3):
         return {'$and': [f1, f2, f3]}
 
 
-def query_and_return(qfilter, coll, find_one, to_table = True):
+def query_and_return(qfilter, projection, coll, find_one, to_table = True):
     """
         query a collection with a given filter and return the results.
         
@@ -82,12 +82,12 @@ def query_and_return(qfilter, coll, find_one, to_table = True):
     """
     
     if find_one:
-        qresult = coll.find_one(qfilter)
+        qresult = coll.find_one(qfilter, projection)
         if qresult is None:
             return None
         qresults = [qresult]
     else:
-        qresults = list(coll.find(qfilter))
+        qresults = list(coll.find(qfilter, projection))
     if len(qresults) == 0:
         return None
     elif to_table:
@@ -98,7 +98,7 @@ def query_and_return(qfilter, coll, find_one, to_table = True):
 
 def searcharound_HEALPix(
     ra, dec, rs_arcsec, src_coll, hp_key, hp_order, hp_nest, hp_resol, 
-    circular, ra_key, dec_key, find_one, pre_filter = None, post_filter = None, logger  = None):
+    circular, ra_key, dec_key, find_one, pre_filter = None, post_filter = None, projection={"_id": 0}, logger  = None):
     """
         Returns sources in catalog contained in the the group of healpixels
         around the target coordinate that covers the search radius.
@@ -202,7 +202,8 @@ def searcharound_HEALPix(
     combined_filter = filters_logical_and(pre_filter, hp_query, post_filter)
     
     # query the database for sources in these pixels
-    qresults = query_and_return(combined_filter, src_coll, find_one, to_table=False)
+    qresults = query_and_return(combined_filter, projection, src_coll, find_one, to_table=False)
+
     if qresults is None:
         return None
     if not circular:
@@ -218,7 +219,7 @@ def searcharound_HEALPix(
 
 
 def searcharound_9HEALPix(ra, dec, src_coll, hp_key, hp_order, hp_nest, hp_resol, 
-    find_one, pre_filter = None, post_filter = None):
+    find_one, pre_filter = None, post_filter = None, projection={"_id": 0}):
     """
         Returns sources in catalog contained in the 9 healpixels
         around the target coordinate.
@@ -278,11 +279,11 @@ def searcharound_9HEALPix(ra, dec, src_coll, hp_key, hp_order, hp_nest, hp_resol
     combined_filter = filters_logical_and(pre_filter, hp_query, post_filter)
 
     # query the database for sources in these pixels
-    return query_and_return(combined_filter, src_coll, find_one)
+    return query_and_return(combined_filter, projection, src_coll, find_one)
 
 
 def searcharound_2Dsphere(ra, dec, rs_arcsec, src_coll, s2d_key, find_one, 
-    pre_filter = None, post_filter = None, logger = None):
+    pre_filter = None, post_filter = None, projection={"_id": 0, "pos": 0}, logger = None):
     """
         Returns sources in catalog within rs_arcsec from target position.
         
@@ -349,10 +350,10 @@ def searcharound_2Dsphere(ra, dec, rs_arcsec, src_coll, s2d_key, find_one,
     combined_filter = filters_logical_and(pre_filter, geoquery, post_filter)
 
     # query and return
-    return query_and_return(combined_filter, src_coll, find_one)
+    return query_and_return(combined_filter, projection, src_coll, find_one)
 
 
-def searcharound_RAW(ra, dec, rs_arcsec, src_coll, ra_key, dec_key, find_one, box_scale = 2, pre_filter = None, post_filter = None):
+def searcharound_RAW(ra, dec, rs_arcsec, src_coll, ra_key, dec_key, find_one, box_scale = 2, pre_filter = None, post_filter = None, projection={"_id": 0, "pos": 0}):
     """
         Returns sources in catalog within rs_arcsec from target position.
         
@@ -421,7 +422,7 @@ def searcharound_RAW(ra, dec, rs_arcsec, src_coll, ra_key, dec_key, find_one, bo
     combined_filter = filters_logical_and(pre_filter, qfilter, post_filter)
 
     # query and return
-    return query_and_return(combined_filter, src_coll, find_one)
+    return query_and_return(combined_filter, projection, src_coll, find_one)
 
 
 def get_distances(ra, dec, table, ra_key, dec_key):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    error

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-filterwarnings =
-    error

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@ filterwarnings =
     error
 addopts = --cov=extcats -rxs
 
+[coverage:run]
+relative_files = True
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[tool:pytest]
+filterwarnings =
+    error
+addopts = --cov=extcats
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
 filterwarnings =
     error
-addopts = --cov=extcats
+addopts = --cov=extcats -rxs
 

--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,5 @@ setup(
     url="https://github.com/AmpelProject/extcats",
     download_url="https://github.com/AmpelProject/extcats/archive/2.4.tar.gz",
     install_requires=["pymongo>=3.7", "healpy", "astropy", "pandas", "tqdm"],
-    extras_require={"testing": ["pytest"]},
+    extras_require={"testing": ["pytest", "pytest-cov"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -8,13 +8,14 @@
 from setuptools import setup
 
 setup(
-    name='extcats',
-    version='2.4',
-    description='Tools to organize and query astronomical catalogs',
-    author='Matteo Giomi',
-    author_email='matteo.giomi@desy.de',
-    packages=['extcats'],
-    url = 'https://github.com/MatteoGiomi/extcats',
-    download_url = 'https://github.com/MatteoGiomi/extcats/archive/2.4.tar.gz',
-    install_requires=['pymongo', 'healpy', 'astropy', 'pandas', 'tqdm'],
-    )
+    name="extcats",
+    version="2.4",
+    description="Tools to organize and query astronomical catalogs",
+    author="Matteo Giomi",
+    author_email="matteo.giomi@desy.de",
+    packages=["extcats"],
+    url="https://github.com/AmpelProject/extcats",
+    download_url="https://github.com/AmpelProject/extcats/archive/2.4.tar.gz",
+    install_requires=["pymongo", "healpy", "astropy", "pandas", "tqdm"],
+    extras_require={"testing": ["pytest"]},
+)

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,6 @@ setup(
     packages=["extcats"],
     url="https://github.com/AmpelProject/extcats",
     download_url="https://github.com/AmpelProject/extcats/archive/2.4.tar.gz",
-    install_requires=["pymongo", "healpy", "astropy", "pandas", "tqdm"],
+    install_requires=["pymongo>=3.7", "healpy", "astropy", "pandas", "tqdm"],
     extras_require={"testing": ["pytest"]},
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,132 @@
+from pathlib import Path
+
+import pandas as pd
+from healpy import ang2pix
+import pymongo
+import pytest
+from extcats import testdata
+from extcats.CatalogPusher import CatalogPusher
+import subprocess
+import json
+
+
+@pytest.fixture(scope="session")
+def data_dir():
+    return Path(__file__).parent / "test-data"
+
+
+@pytest.fixture(scope="session")
+def mongo_db(pytestconfig):
+    """
+    Bring up an instance of mongo in Docker
+    """
+    # if not pytestconfig.getoption("--integration"):
+    #     raise pytest.skip("integration tests require --integration flag")
+    try:
+        container_id = (
+            subprocess.check_output(
+                ["docker", "run", "-d", "--rm", "-P", "mongo:4.0"],
+            )
+            .strip()
+            .decode()
+        )
+    except FileNotFoundError:
+        raise pytest.skip("integration test requires docker")
+    try:
+        port = json.loads(
+            subprocess.check_output(
+                ["docker", "inspect", container_id],
+            ).decode()
+        )[0]["NetworkSettings"]["Ports"]["27017/tcp"][0]["HostPort"]
+        yield f"mongodb://localhost:{port}"
+    finally:
+        subprocess.check_output(
+            ["docker", "stop", container_id],
+        )
+
+
+@pytest.fixture(scope="session")
+def mongo_client(mongo_db):
+    return pymongo.MongoClient(mongo_db)
+
+
+@pytest.fixture(scope="session")
+def milliquas(data_dir, mongo_client):
+    # obtained with:
+    # wget https://heasarc.gsfc.nasa.gov/FTP/heasarc/dbase/tdat_files/heasarc_milliquas.tdat.gz
+    # gzcat heasarc_milliquas.tdat.gz| head -n 100 > heasarc_milliquas_sample.tdat
+    # echo '<END>' >> heasarc_milliquas_sample.tdat
+    mqp = CatalogPusher(
+        catalog_name="milliquas",
+        data_source=str(data_dir / "milliquas"),
+        file_type="tdat",
+    )
+    columns = [
+        "name",
+        "ra",
+        "dec",
+        "lii",
+        "bii",
+        "broad_type",
+        "rmag",
+        "bmag",
+        "optical_flag",
+        "red_psf_flag",
+        "blue_psf_flag",
+        "redshift",
+        "ref_name",
+        "ref_redshift",
+        "qso_prob",
+        "radio_name",
+        "xray_name",
+        "alt_name_1",
+        "alt_name_2",
+        "class",
+    ]
+    mqp.assign_file_reader(
+        reader_func=pd.read_table,
+        read_chunks=True,
+        names=columns,
+        chunksize=50000,
+        engine="c",
+        skiprows=65,
+        skip_blank_lines=True,
+        sep="|",
+        index_col=False,
+        comment="<",
+    )
+
+    def mqc_modifier(srcdict):
+        # format coordinates into geoJSON type (commented version uses 'legacy' pair):
+        # unfortunately mongo needs the RA to be folded into -180, +180
+        ra = srcdict["ra"] if srcdict["ra"] < 180.0 else srcdict["ra"] - 360.0
+        srcdict["pos"] = {"type": "Point", "coordinates": [ra, srcdict["dec"]]}
+
+        # add healpix index
+        srcdict["hpxid_16"] = int(
+            ang2pix(2 ** 16, srcdict["ra"], srcdict["dec"], lonlat=True, nest=True)
+        )
+
+        return srcdict
+
+    mqp.assign_dict_modifier(mqc_modifier)
+
+    mqp.push_to_db(
+        coll_name="srcs",
+        index_on=["hpxid_16", [("pos", pymongo.GEOSPHERE)]],
+        index_args=[{}, {}],  # specify arguments for the index creation
+        overwrite_coll=False,
+        append_to_coll=False,
+        dbclient=mongo_client,
+    )
+
+    assert mqp.coll.count_documents({}) == 34
+
+    mqp.healpix_meta(healpix_id_key="hpxid_16", order=16, is_indexed=True, nest=True)
+    mqp.sphere2d_meta(sphere2d_key="pos", is_indexed=True, pos_format="geoJSON")
+    mqp.science_meta(
+        contact="C. Norris",
+        email="chuck.norris@desy.de",
+        description="compilation of AGN and Quasar",
+        reference="http://quasars.org/milliquas.htm",
+    )

--- a/tests/test-data/milliquas/heasarc_milliquas_sample.tdat
+++ b/tests/test-data/milliquas/heasarc_milliquas_sample.tdat
@@ -1,0 +1,101 @@
+<HEADER>
+#
+#         TABLE: heasarc_milliquas
+#      LOCATION: dbms1.gsfc.nasa.gov:heasarcprod
+#    TOTAL ROWS: 1445913
+#
+# CREATION DATE: 2020-10-02 16:23:54
+# LAST MODIFIED: 2020-10-02 16:23:54
+#   EXGEST DATE: 2020-10-05 19:21:08
+#
+table_name = heasarc_milliquas
+table_description = "Million Quasars Catalog (MILLIQUAS), Version 7.0 (30 September 2020)"
+table_document_url = http://heasarc.gsfc.nasa.gov/W3Browse/galaxy-catalog/milliquas.html
+table_security = public
+#
+# Table Parameters
+#
+field[name] = char25  [meta.id;meta.main] (index) // Source Identification from the Literature
+field[ra] = float8:.5f_degree [pos.eq.ra;meta.main] (key) // Right Ascension
+field[dec] = float8:.5f_degree [pos.eq.dec;meta.main] (key) // Declination
+field[lii] = float8:.5f_degree [pos.galactic.lon] (index) // Galactic Longitude
+field[bii] = float8:.5f_degree [pos.galactic.lat] (index) // Galactic Latitude
+field[broad_type] = char4  [src.class] (index) // Broad Classification of Object
+field[rmag] = float8:5.2f_mag [phot.mag;em.opt.R] (index) // Red Optical Magnitude
+field[bmag] = float8:5.2f_mag [phot.mag;em.opt.B] (index) // Blue Optical Magnitude
+field[optical_flag] = char3  [meta.code;em.opt] (index) // Flags Indicate Comments on Optical Object
+field[red_psf_flag] = char1  [meta.code;instr.det.psf]  // Flag Indicates Red Optical PSF Class
+field[blue_psf_flag] = char1  [meta.code;instr.det.psf]  // Flag Indicates Blue Optical PSF Class
+field[redshift] = float8:6.3f  [src.redshift] (index) // Redshift from the Literature or Estimated
+field[ref_name] = char6  [meta.ref;meta.id] (index) // Reference Code for the Source Identification from the Literature
+field[ref_redshift] = char6  [meta.ref;src.redshift] (index) // Reference Code for the Redshift from the Literature
+field[qso_prob] = int2:3d_percent [stat.probability] (index) // Probability That This Object Is a QSO
+field[radio_name] = char22  [meta.id.assoc;em.radio] (index) // Radio Identification, If Any
+field[xray_name] = char22  [meta.id.assoc;em.X-ray] (index) // X-Ray Identification, If Any, But Can Be Radio Lobe If Radio Source
+field[alt_name_1] = char22  [meta.id.assoc;em.radio] (index) // Radio Lobe Identification or Additional Radio or X-Ray Identification
+field[alt_name_2] = char22  [meta.id.assoc;em.radio] (index) // Additional Radio Lobe Identification or X-Ray Identification
+field[class] = int2  [src.class] (index) // Browse Object Classification
+#
+parameter_defaults = name ra dec bmag rmag redshift radio_name xray_name
+#
+# Virtual Parameters
+#
+catalog_bibcode = 2015PASA...32...10F
+declination = @dec
+default_search_radius = 1
+equinox = 2000
+frequency_regime = Optical
+observatory_name = GALAXY CATALOG
+right_ascension = @ra
+row_type = Survey Source
+table_author = Flesch
+table_info_url = http://quasars.org/milliquas.htm
+table_priority = 5
+table_type = Object
+target_name = @name
+unique_key = name
+#
+# Relationship Definitions
+#
+relate[class] = heasarc_class(class_id)
+#
+# Data Format Specification
+#
+line[1] = name ra dec lii bii broad_type rmag bmag optical_flag red_psf_flag blue_psf_flag redshift ref_name ref_redshift qso_prob radio_name xray_name alt_name_1 alt_name_2 class
+#
+<DATA>
+WISEA J043431.62-894617.9|68.6369186|-89.7716355|302.71950796|-27.25652568|q|19.2|19.34|jG|-|-|1.7|WISEA|MQ|100|||||7204|
+WISEA J094017.96-894442.8|145.0760539|-89.7452383|302.72023987|-26.95690938|q|18.58|19.27|jG|-|n|1|WISEA|MQ|96|||||7204|
+WISEA J192247.55-893602.5|290.6981431|-89.600695|303.37660399|-27.1820097|q|20.25|21.13|j|1|-|1.6|WISEA|MQ|98|||||7204|
+WISEA J174333.00-893514.8|265.8887235|-89.5874561|303.37479344|-27.00714205|q|19.07|18.68|jmG|1|-|0.6|WISEA|MQ|98|||||7204|
+WISEA J214955.49-893435.5|327.4812657|-89.5765297|303.2714897|-27.4252982|q|18.67|19.85|jG|-|1|2.4|WISEA|MQ|95|||||7204|
+WISEA J094526.46-893159.0|146.3563831|-89.5330643|302.55241599|-26.80634261|q|19.8|20.19|jG|1|n|0.8|WISEA|MQ|91|||||7204|
+WISEA J212638.23-892859.5|321.6626118|-89.4832061|303.3857575|-27.4513683|q|19.88|21.05|jG|n|1||WISEA||84|||||7204|
+WISEA J045305.39-892601.5|73.271934|-89.4337761|302.37727662|-27.40673577|q|19.08|20.23|jG|-|1|0.3|WISEA|MQ|94|||||7204|
+WISEA J174350.23-892550.8|265.9589389|-89.4307816|303.54296773|-26.96145129|q|17.7|18.61|jG|-|-|2.1|WISEA|MQ|99|||||7204|
+WISEA J005023.03-892532.2|12.5964651|-89.4256068|302.9348962|-27.70263837|q|18.93|19.9|jG|-|-|1|WISEA|MQ|100|||||7204|
+WISEA J222301.23-892309.1|335.7540586|-89.3858719|303.35004827|-27.61741504|qX|17.26|17.57|jG|-|-|0.9|WISEA|MQ|100||2SXPS J222300.2-892309|||7204|
+WISEA J161901.50-892201.9|244.756825|-89.3672057|303.48947805|-26.73667152|q|20.09|21.06|jG|-|n|0.6|WISEA|MQ|95|||||7204|
+WISEA J180334.09-892201.6|270.8907935|-89.3670879|303.6267839|-26.99529038|q|20.08|20.82|jG|1|1|1.3|WISEA|MQ|100|||||7204|
+WISEA J095358.71-892139.7|148.496477|-89.3610872|302.43200264|-26.67059292|q|19.43|20.27|jG|n|-|1.5|WISEA|MQ|100|||||7204|
+WISEA J015835.73-892019.8|29.6484489|-89.3388774|302.71611948|-27.76102843|q|19.03|20.05|jG|1|-|0.3|WISEA|MQ|96|||||7204|
+WISEA J044013.91-891855.0|70.0588381|-89.315292|302.28308167|-27.49767745|q|19.46|20.74|jG|-|-|0.2|WISEA|MQ|90|||||7204|
+WISEA J225659.24-891826.1|344.2463408|-89.3072793|303.3067149|-27.735874|q|16.95|17.54|jG|n|1|0.1|WISEA|MQ|99|||||7204|
+WISEA J014318.28-891742.3|25.8175424|-89.295084|302.75320409|-27.81510291|q|17.53|19.03|jG|1|-|1.8|WISEA|MQ|88|||||7204|
+WISEA J143939.75-891725.3|219.9174586|-89.2903414|303.29261502|-26.49580714|q|19.34|20.07|jG|1|-|0.3|WISEA|MQ|98|||||7204|
+WISEA J171637.43-891552.4|259.1555297|-89.264386|303.68673198|-26.83051014|q|19.55|20.71|jG|-|-|1.7|WISEA|MQ|98|||||7204|
+WISEA J153947.23-891549.4|234.9496029|-89.2636885|303.48379132|-26.5807637|q|19.04|19.33|jG|-|-|0.8|WISEA|MQ|99|||||7204|
+WISEA J133527.43-891437.1|203.86557|-89.2436532|303.0931026|-26.38572419|q|19.09|19.29|jG|1|1|0.6|WISEA|MQ|98|||||7204|
+WISEA J122148.50-891431.2|185.452993|-89.2419933|302.82285359|-26.37652689|q|18.95|18.78|jG|-|1|1.7|WISEA|MQ|100|||||7204|
+WISEA J232334.06-891159.3|350.8956605|-89.1998582|303.27044538|-27.8699124|q|20.27|20.65|jG|n|1|1.1|WISEA|MQ|100|||||7204|
+WISEA J213247.49-891140.5|323.1981326|-89.1945869|303.62495853|-27.64789545|q|19.77|20.71|jG|-|-|2.2|WISEA|MQ|98|||||7204|
+WISEA J070143.81-891039.1|105.439846|-89.1774848|302.00899051|-27.08820476|q|19.32|19.6|jG|-|1|1.1|WISEA|MQ|99|||||7204|
+WISEA J161013.42-891012.2|242.5543061|-89.1700216|303.63972242|-26.58960072|q|20.77|19.8|jG|-|1|2|WISEA|MQ|80|||||7204|
+WISEA J022901.56-890908.3|37.2577281|-89.1522868|302.53570504|-27.89970361|q|20.36|20.86|jG|-|n|0.3|WISEA|MQ|97|||||7204|
+WISEA J203030.53-890841.6|307.6294375|-89.1450047|303.80701488|-27.48375948|q|19.96|20.88|jG|-|-|0.4|WISEA|MQ|97|||||7204|
+WISEA J224917.93-890819.0|342.3240278|-89.1386416|303.42695484|-27.86928279|q|19.82|20.87|jmG|-|-|1.4|WISEA|MQ|99|||||7204|
+WISEA J231320.96-890753.7|348.3456884|-89.1316188|303.3396625|-27.91776797|q|19.88|21.12|jG|-|1|1.4|WISEA|MQ|88|||||7204|
+WISEA J012938.55-890710.9|22.4108824|-89.1197826|302.76651102|-27.99616924|q|19.28|19.25|jG|1|-|0.8|WISEA|MQ|99|||||7204|
+WISEA J032900.52-890704.0|52.2496419|-89.1178183|302.2990035|-27.80861798|q|17.7|18.83|jG|n|1|0.1|WISEA|MQ|89|||||7204|
+WISEA J072941.57-890703.0|112.4232528|-89.1175408|301.95545646|-26.97825934|q|18.34|19.44|jmG|-|-|1.4|WISEA|MQ|98|||||7204|
+<END>

--- a/tests/test_CatalogQuery.py
+++ b/tests/test_CatalogQuery.py
@@ -9,13 +9,7 @@ def catq(milliquas, mongo_client):
 
 with_index_methods = pytest.mark.parametrize(
     "method",
-    [
-        "2dsphere",
-        "healpix",
-        pytest.param(
-            "raw", marks=pytest.mark.xfail(reason="raw has likely never worked")
-        ),
-    ],
+    ["2dsphere", "healpix"],
 )
 
 

--- a/tests/test_CatalogQuery.py
+++ b/tests/test_CatalogQuery.py
@@ -1,0 +1,38 @@
+import pytest
+from extcats.CatalogQuery import CatalogQuery
+
+
+@pytest.fixture
+def catq(milliquas, mongo_client):
+    return CatalogQuery("milliquas", dbclient=mongo_client)
+
+
+with_index_methods = pytest.mark.parametrize(
+    "method",
+    [
+        "2dsphere",
+        "healpix",
+        pytest.param(
+            "raw", marks=pytest.mark.xfail(reason="raw has likely never worked")
+        ),
+    ],
+)
+
+
+@with_index_methods
+def test_findwithin(catq, method):
+    assert len(catq.findwithin(185.453, -89.241, 10, method=method)) == 1
+    assert catq.findwithin(0, -90, 10, method=method) is None
+
+
+@with_index_methods
+def test_findclosest(catq, method):
+    match, dist = catq.findclosest(185.453, -89.241, 10, method=method)
+    assert dist == pytest.approx(3.5758, abs=1e-4)
+    assert catq.findwithin(0, -90, 10) is None
+
+
+@with_index_methods
+def test_binarysearch(catq, method):
+    assert catq.binaryserach(185.453, -89.241, 10, method=method) is True
+    assert catq.binaryserach(0, -90, 10, method=method) is False


### PR DESCRIPTION
Generate `_ra` and `_dec` columns from geoJSON field for use with `CatalogQuery.findclosest()`. This makes `ra_key` and `dec_key` actually optional for catalogs with a geoJSON index. For healpix-only catalogs, the ra/dec keys are stored in the meta collection, e.g. `{_id: "keys", "ra": "RAJ2000", "dec": "DEJ2000"}`.

Other improvements:
- Integration test
- Fix pymongo deprecation warnings
- Test coverage tracking