### PR TITLE
Revert "CatalogQuery: fix debug output"

### DIFF
--- a/extcats/CatalogQuery.py
+++ b/extcats/CatalogQuery.py
@@ -66,7 +66,7 @@ class CatalogQuery():
         self.dbclient = dbclient
         if dbclient is None:
             self.dbclient = pymongo.MongoClient()
-        self.logger.debug("using mongo client at %s" % self.dbclient.address)
+        self.logger.debug("using mongo client at %s:%d"%(self.dbclient.address))
         
         # find database and collection
         if not cat_name in self.dbclient.database_names():


### PR DESCRIPTION
MongoClient.address is a 2-tuple, and so can't be used to format a string with only 1 format specifier.

Reverts AmpelProject/extcats#7